### PR TITLE
(chore): prefer autogenerated readme

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,6 +1,5 @@
 # Specify files that shouldn't be modified by Fern
 
 # Top-level files and folders
-README.md
 examples
 .idea


### PR DESCRIPTION
Removes readme from `.fernignore` so that Fern can generate you one.